### PR TITLE
New device Yotece 1200

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 sftp-config.json
 *.o
+*.o.cmd
 *.ko
+*.ko.cmd

--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -221,9 +221,11 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 
 #ifdef CONFIG_RTL8822B
 	/*=== Realtek demoboard ===*/
+	{USB_DEVICE(0x0BDA, 0xB812), .driver_info = RTL8822B}, /* FCLT */
 	{USB_DEVICE(0x0B05, 0x1812), .driver_info = RTL8812}, /* ASUS - Edimax */
 	{USB_DEVICE(0x7392, 0xB822), .driver_info = RTL8822B}, /* Edimax - EW-7822ULC */
 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_REALTEK, 0xB82C, 0xff, 0xff, 0xff), .driver_info = RTL8822B}, /* Default ID */
+	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_REALTEK, 0xB812, 0xff, 0xff, 0xff), .driver_info = RTL8822B}, /* Default ID */
 #endif /* CONFIG_RTL8822B */
 
 #ifdef CONFIG_RTL8723D


### PR DESCRIPTION
Added Realtek device `0bda:b812`.

It is a WLAN-adapter from yotece. See

- https://www.amazon.de/gp/product/B07572GGNP/ref=oh_aui_detailpage_o00_s02?ie=UTF8&psc=1
- https://wikidevi.com/wiki/YOTECE_AC1200